### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "btoa": "bin/btoa.js"
   },
   "main": "index",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "version": "1.1.2"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
